### PR TITLE
fix multmerge when csv files do not contain all sentences

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,7 @@ multmerge <- function(filenames) {
     })
   if (!validate_names(datalist))
     stop("Key translation is not the same in all files.")
-  Reduce(function(x, y) {merge(x, y)}, datalist)
+  Reduce(function(x, y) {merge(x, y, all = TRUE)}, datalist)
 }
 
 #' Validate Column Names


### PR DESCRIPTION
For now, when using csv files, the translation dataframe contains the intersection of the sentences over all languages.
I propose to use the union.