### PR TITLE
Fixed issue with loading live_language_change example app

### DIFF
--- a/inst/examples/live_language_change/app.R
+++ b/inst/examples/live_language_change/app.R
@@ -49,7 +49,7 @@ server <- shinyServer(function(input, output, session) {
   })
 
   observeEvent(i18n(), {
-    updateSliderInput(session, "bins", label =  i18n()$t("Number of bins:"), value = input$bins)
+    updateSliderInput(session, "bins", label =  i18n()$t("Number of bins:"), value = req(input$bins))
   })
 
 })


### PR DESCRIPTION
fixes #25  
live_language_change example crashing on start - the problem was with NULL slider value at the start in updateSliderInput()