### PR TITLE
Allow translations in modules

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -77,5 +77,6 @@ usei18n <- function(translator) {
 #' @export
 #' @seealso usei18n
 update_lang <- function(session, language) {
+  if (inherits(session, "session_proxy")) session <- session$rootScope()
   session$sendInputMessage("i18n-state", list(lang = language))
 }


### PR DESCRIPTION
Solution to #48, alternative approach to the one in #49.

Solution in mentioned PR requires to add `usei18n(translator, ns)` in each module to allow using `update_lang`. Proposed one allows to add `usei18n` only once in the app.  If `update_lang` is called in a module `session` argument is of class `session_proxy`. To make `sendInputMessage` work (not to use namespace) a root session has to be used which can be accesses using `session$rootScope()`