### PR TITLE
Rhino compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,14 @@
 Package: shiny.i18n
 Title: Shiny Applications Internationalization
-Version: 0.2.1
-Authors@R: c(person("Dominik", "Krzemiński",
-                    email = "dominik@appsilon.com",
-                    role = c("aut")),
-            person("Krystian", "Igras",
-                    email = "krystian@appsilon.com",
-                    role = c("aut")),
-            person("Jakub", "Sobolewski",
-                    email = "jakub.sobolewski@appsilon.com",
-                    role = c("cre")),
-            person(family = "Appsilon", role = c("cph")))
+Version: 0.2.1.9000
+Authors@R:
+  c(
+    person("Jakub", "Nowicki", email = "opensource+kuba@appsilon.com", role = c("cre", "aut")),
+    person("Dominik", "Krzemiński", email = "raymon92@gmail.com", role = c("aut")),
+    person("Krystian", "Igras", email = "krystian8207@gmail.com", role = c("aut")),
+    person("Jakub", "Sobolewski", email = "jakub.sobolewski@appsilon.com", role = c("aut")),
+    person("Appsilon Sp. z o.o.", role = "cph", email = "opensource@appsilon.com")
+  )
 Description: It provides easy internationalization of Shiny
     applications. It can be used as standalone translation package
     to translate reports, interactive visualizations or
@@ -28,7 +26,7 @@ Imports: yaml,
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-URL: https://github.com/Appsilon/shiny.i18n
+URL: https://appsilon.github.io/shiny.i18n/, https://github.com/Appsilon/shiny.i18n
 BugReports: https://github.com/Appsilon/shiny.i18n/issues
 RoxygenNote: 7.2.1
 Suggests:

--- a/R/translator.R
+++ b/R/translator.R
@@ -95,8 +95,8 @@ Translator <- R6Class( #nolint
     #' @param session Shiny server session (default: current reactive domain)
     translate = function(keyword, session = shiny::getDefaultReactiveDomain()) {
       if (!is.null(session)) {
-        translation_language <- if (!is.null(session$input$`i18n-state`)) {
-          session$input$`i18n-state`
+        translation_language <- if (!is.null(session$userData$shiny.i18n$lang)) {
+          session$userData$shiny.i18n$lang()
         } else {
           private$translation_language
         }

--- a/R/ui.R
+++ b/R/ui.R
@@ -82,4 +82,8 @@ usei18n <- function(translator) {
 update_lang <- function(session, language) {
   if (inherits(session, "session_proxy")) session <- session$rootScope()
   session$sendInputMessage("i18n-state", list(lang = language))
+  if (is.null(session$userData$shiny.i18n$lang)) {
+    session$userData$shiny.i18n$lang <- reactiveVal()
+  }
+  session$userData$shiny.i18n$lang(language)
 }

--- a/examples/live_language_change/browser_app_modules.R
+++ b/examples/live_language_change/browser_app_modules.R
@@ -1,0 +1,89 @@
+#' This script demonstrates how to use shiny.i18n Translator object
+#' for live language change on the UI side with Shiny modules. Two key steps are:
+#' (a) add `usei18n(i18n)` to UI
+#' (b) use `update_lang` function to change the language in session
+
+library(shiny)
+library(shiny.i18n)
+
+# File with translations
+i18n <- Translator$new(translation_csvs_path = "../data/")
+i18n$set_translation_language("en") # here you select the default translation to display
+
+ui_module <- function(id) {
+  ns <- NS(id)
+
+  tagList(
+    shiny.i18n::usei18n(i18n),
+    div(
+      style = "float: right;",
+      selectInput(ns("selected_language"),
+        i18n$t("Change language"),
+        choices = i18n$get_languages(),
+        selected = i18n$get_key_translation()
+      )
+    ),
+    titlePanel(i18n$t("Hello Shiny!"), windowTitle = NULL),
+    sidebarLayout(
+      sidebarPanel(
+        sliderInput(ns("bins"),
+          i18n$t("Number of bins:"), # you use i18n object as always
+          min = 1,
+          max = 50,
+          value = 30
+        )
+      ),
+      plot_ui_module(ns("plot"))
+    )
+  )
+}
+
+plot_ui_module <- function(id) {
+  ns <- NS(id)
+
+  mainPanel(
+    plotOutput(ns("distPlot")),
+    p(i18n$t("This is description of the plot."))
+  )
+}
+
+server_module <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    # ObserveEvent to listen the select input values
+    observeEvent(input$selected_language, {
+      # This print is just for demonstration
+      print(paste("Language change!", input$selected_language))
+      # Here is where we update language in session
+      shiny.i18n::update_lang(session, input$selected_language)
+    })
+
+    server_plot_module("plot", reactive(input$bins))
+  })
+}
+
+server_plot_module <- function(id, bins) {
+  moduleServer(id, function(input, output, session) {
+    output$distPlot <- renderPlot({
+      x <- datasets::faithful[, 2]
+      bins <- seq(min(x), max(x), length.out = bins() + 1)
+      hist(
+        x,
+        breaks = bins,
+        col = "darkgray",
+        border = "white",
+        main = i18n$t("Histogram of x"),
+        ylab = i18n$t("Frequency")
+      )
+    })
+  })
+}
+
+ui <- fluidPage(
+  ui_module("app")
+)
+
+server <- function(input, output, session) {
+  server_module("app")
+}
+
+shinyApp(ui, server)

--- a/examples/live_language_change/browser_app_modules.R
+++ b/examples/live_language_change/browser_app_modules.R
@@ -14,7 +14,7 @@ ui_module <- function(id) {
   ns <- NS(id)
 
   tagList(
-    shiny.i18n::usei18n(i18n),
+    usei18n(i18n),
     div(
       style = "float: right;",
       selectInput(ns("selected_language"),
@@ -54,7 +54,7 @@ server_module <- function(id) {
       # This print is just for demonstration
       print(paste("Language change!", input$selected_language))
       # Here is where we update language in session
-      shiny.i18n::update_lang(session, input$selected_language)
+      update_lang(session, input$selected_language)
     })
 
     server_plot_module("plot", reactive(input$bins))


### PR DESCRIPTION
# Fix compatibility with `rhino`

Closes #86 

Fixes "browser" live update functionality in Shiny applications with Shiny modules (which includes Rhino applications).

How to test?
All examples for live language change work.