### PR TITLE
fix: order of the arguments in the example

### DIFF
--- a/vignettes/basics.Rmd
+++ b/vignettes/basics.Rmd
@@ -128,7 +128,7 @@ ui <- fluidPage(usei18n(i18n),
 
 server <- function(input, output, session) {
   observeEvent(input$go,{
-       update_lang(session, "pl")
+       update_lang("pl", session)
   })
 }
 


### PR DESCRIPTION
# Description

In the tutorial, the order of arguments is reversed. Doing it the way it is written sends the language code to the session variable which leads to the `$ is not applicable for atomic vectors` error since "en" or "pl" would be a string and not a `session` object. There is nothing wrong with the `update_lang()` function (I've checked that as well). 

The PR fixes the tutorial with a small commit.
