### PR TITLE
Refactored preproc functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,18 +17,19 @@ Depends: R (>= 3.3.0)
 Imports: yaml,
          jsonlite,
          methods,
-         stringr,
+         stringi,
          R6,
          glue,
          shiny,
          rstudioapi,
-         utils
+         utils,
+         data.table
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 URL: https://appsilon.github.io/shiny.i18n/, https://github.com/Appsilon/shiny.i18n
 BugReports: https://github.com/Appsilon/shiny.i18n/issues
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Suggests:
     covr,
     googleLanguageR,

--- a/R/preproc.R
+++ b/R/preproc.R
@@ -20,9 +20,11 @@ extract_key_expressions <- function(str, handle = "i18n") {
     pattern = c(
       glue::glue("{handle}\\$t\\([\"']"),
       glue::glue("{handle}\\$translate\\([\"']"),
-      "[\"']\\)$"
+      "[\"']\\)$",
+      "\\\\r",
+      "\\\\n"
     ),
-    replacement = c("", "", ""),
+    replacement = c("", "", "", "\r", "\n"),
     vectorize_all = FALSE
   ))
 }

--- a/R/preproc.R
+++ b/R/preproc.R
@@ -10,18 +10,19 @@
 extract_key_expressions <- function(str, handle = "i18n") {
   found <- stri_remove_empty_na(stri_extract_all_regex(
     str,
-    glue::glue(
+    pattern = glue::glue(
       "{handle}\\$t\\(([\"']).*?\\1\\)|{handle}\\$translate\\(([\"']).*?\\2\\)"
-    )
+    ),
+    simplify = TRUE
   ))
   stri_unique(stri_replace_all_regex(
-    found,
-    c(
+    str = found,
+    pattern = c(
       glue::glue("{handle}\\$t\\([\"']"),
       glue::glue("{handle}\\$translate\\([\"']"),
       "[\"']\\)$"
     ),
-    c("", "", ""),
+    replacement = c("", "", ""),
     vectorize_all = FALSE
   ))
 }

--- a/R/preproc.R
+++ b/R/preproc.R
@@ -11,7 +11,7 @@ extract_key_expressions <- function(str, handle = "i18n") {
   found <- stri_remove_empty_na(stri_extract_all_regex(
     str,
     pattern = glue::glue(
-      "{handle}\\$t\\(([\"']).*?\\1\\)|{handle}\\$translate\\(([\"']).*?\\2\\)"
+      "{handle}\\$t\\(([\"'])(?s).*?\\1\\)|{handle}\\$translate\\(([\"'])(?s).*?\\2\\)"
     ),
     simplify = TRUE
   ))

--- a/R/preproc.R
+++ b/R/preproc.R
@@ -38,6 +38,7 @@ extract_key_expressions <- function(str, handle = "i18n") {
 #' @param update logical. If TRUE, the output updates the existing translation file. If FALSE, any existing file of the name is overwritten.
 #' @import stats
 #' @import data.table
+#' @importFrom jsonlite read_json
 #' @keywords internal
 prepare_translation_table <- function(key_expressions,
                          output_path = NULL,

--- a/R/preproc.R
+++ b/R/preproc.R
@@ -172,7 +172,7 @@ save_to_csv <- function(key_expressions,
 #' Create translation file
 #'
 #' Auxiliary shiny.i18n function that searches for all key expressions (e.g.
-#' surrounded by \code{i18n$t()} tag in the script).
+#' surrounded by \code{i18n$t()} tag in the provided scripts).
 #'
 #' @param path character vector of one or more paths of the file(s) that needs to be inspected for
 #' key translations

--- a/R/preproc.R
+++ b/R/preproc.R
@@ -1,23 +1,102 @@
 #' Extract key expressions
 #'
-#' @param text character with text of the script
+#' @param str character vector; strings to search within
 #' @param handle character with Translator object handle (default: 'i18n')
 #'
 #' @return vector of characters with key expressions
-#' @import stringr
+#' @import stringi
 #' @import glue
 #' @keywords internal
-extract_key_expressions <- function(text, handle = "i18n") {
-  found <- unlist(str_extract_all(text, glue::glue("{handle}\\$t\\(([\"']).*?\\1\\)")))
-  ke1 <- str_replace(str_replace(found, glue::glue("{handle}\\$t\\([\"']"), ""), "[\"']\\)$", "")
-  found <- unlist(str_extract_all(text, glue::glue("{handle}\\$translate\\(([\"']).*?\\1\\)")))
-  ke2 <- str_replace(
-    str_replace(found, glue::glue("{handle}\\$translate\\([\"']"), ""),
-    "[\"']\\)$",
-    ""
-  )
-  key_expressions <- c(ke1, ke2)
-  key_expressions
+extract_key_expressions <- function(str, handle = "i18n") {
+  found <- stri_remove_empty_na(stri_extract_all_regex(
+    str,
+    glue::glue(
+      "{handle}\\$t\\(([\"']).*?\\1\\)|{handle}\\$translate\\(([\"']).*?\\2\\)"
+    )
+  ))
+  stri_unique(stri_replace_all_regex(
+    found,
+    c(
+      glue::glue("{handle}\\$t\\([\"']"),
+      glue::glue("{handle}\\$translate\\([\"']"),
+      "[\"']\\)$"
+    ),
+    c("", "", ""),
+    vectorize_all = FALSE
+  ))
+}
+
+#' Transform key_expressions to data.table and merge with previously existing translations
+#'
+#' @param key_expressions vector with key expression to translate
+#' @param output_path character with path to output file (default:
+#' "translation.json" if NULL)
+#' @param type type of the example output file with translations, either "json"
+#' or "csv"
+#' @param key_language character specifying the language key code of the key_expressions
+#' @param translated_languages character vector specifying the key codes of the translated languages
+#' @param update logical. If TRUE, the output updates the existing translation file. If FALSE, any existing file of the name is overwritten.
+#' @import stats
+#' @import data.table
+#' @keywords internal
+prepare_translation_table <- function(key_expressions,
+                         output_path = NULL,
+                         type = "json",
+                         key_language = "key",
+                         translated_languages = c("language_code_1", "language_code_2"),
+                         update = TRUE) {
+  ..keep_translated_languages <- ..write_columns <- `..`  <- `.` <- NULL # avoid NOTE "no visible binding for global variable"
+  extracted_translation_table <- data.table(key_expressions)
+  names(extracted_translation_table) <- key_language
+
+  if (type == "json") {
+    if (update && file.exists(output_path)) {
+      old_translation_list <- jsonlite::read_json(output_path, simplifyVector = TRUE)
+      old_translation_table <- old_translation_list$translation
+      if (is.data.frame(old_translation_table)) {setDT(old_translation_table)}
+
+      new_translated_languages <- setdiff(translated_languages, names(old_translation_table))
+      extracted_translation_table[, (new_translated_languages) := .("")]
+      if (is.data.table(old_translation_table) && key_language %in% names(old_translation_table)) {
+        keep_translated_languages <- c(key_language, setdiff(names(old_translation_table), names(extracted_translation_table)))
+        # check for intersections
+        extracted_translation_table <- old_translation_table[, ..keep_translated_languages][extracted_translation_table, on = key_language]
+        # merge extracted and previously existing translation tables
+        extracted_translation_table <- rbind(old_translation_table[!extracted_translation_table, on = key_language], extracted_translation_table, use.names = TRUE, fill = TRUE)
+      }
+    } else {
+      extracted_translation_table[, (translated_languages) := .("")]
+    }
+  }
+
+  if (type == "csv") {
+    target_csv_files <- file.path(output_path, paste0("translation_", translated_languages, ".csv"))
+    if (update && any(file.exists(target_csv_files))) {
+      old_translation_tables <- lapply(target_csv_files, function(target_csv_file){fread(target_csv_file, colClasses="character")})
+      old_translation_tables <- setNames(old_translation_tables, sapply(old_translation_tables, function(x){names(x)[2L]}))
+      old_translation_table <- rbindlist(old_translation_tables, use.names = FALSE, fill = FALSE, idcol = "language_code")
+      old_translation_table <- dcast.data.table(old_translation_table, key ~ language_code, value.var = setdiff(names(old_translation_table), c("key", "language_code")))
+
+      new_translated_languages <- setdiff(translated_languages, names(old_translation_table))
+      extracted_translation_table[, (new_translated_languages) := .("")]
+      if (is.data.table(old_translation_table) && key_language %in% names(old_translation_table)) {
+        keep_translated_languages <- c(key_language, setdiff(names(old_translation_table), names(extracted_translation_table)))
+        # check for intersections
+        extracted_translation_table <- old_translation_table[, ..keep_translated_languages][extracted_translation_table, on = key_language]
+        # merge extracted and previously existing translation tables
+        extracted_translation_table <- rbind(old_translation_table[!extracted_translation_table, on = key_language], extracted_translation_table, use.names = TRUE, fill = TRUE)
+      }
+    } else {
+      extracted_translation_table[, (translated_languages) := .("")]
+    }
+  }
+
+  # replace NAs with empty strings
+  for (i in seq_len(ncol(extracted_translation_table))){
+    set(extracted_translation_table, which(is.na(extracted_translation_table[[i]])), i, "")
+  }
+
+  return(extracted_translation_table)
 }
 
 #' Save example i18n file to json
@@ -28,37 +107,64 @@ extract_key_expressions <- function(text, handle = "i18n") {
 #' @param key_expressions vector with key expression to translate
 #' @param output_path character with path to output file (default:
 #' "translation.json" if NULL)
-#' @importFrom jsonlite unbox write_json
+#' @param key_language character specifying the language key code of the key_expressions
+#' @param translated_languages character vector specifying the key codes of the translated languages
+#' @param update logical. If TRUE, the output updates the existing translation file. If FALSE, any existing file of the name is overwritten.
 #' @keywords internal
-save_to_json <- function(key_expressions, output_path = NULL) {
+save_to_json <- function(key_expressions,
+                         output_path = NULL,
+                         key_language = "key",
+                         translated_languages = c("language_code_1", "language_code_2"),
+                         update = TRUE) {
+  if (is.null(output_path)) {output_path <- "translation.json"}
+
+  extracted_translation_table <- prepare_translation_table(key_expressions,
+                                                           output_path,
+                                                           type = "json",
+                                                           key_language,
+                                                           translated_languages,
+                                                           update)
+
   list_to_save <- list(
-    translation = lapply(
-      key_expressions,
-      function(x) list(key = unbox(x))
-    ),
-    languages = "key"
+    languages = c(key_language, translated_languages),
+    translation = extracted_translation_table
   )
 
-  if (is.null(output_path)) output_path <- "translation.json"
-  write_json(list_to_save, output_path)
+  jsonlite::write_json(list_to_save, output_path, pretty = TRUE)
 }
 
-#' Save example i18n file to CSV
+#' Save example i18n table to CSVs
 #'
-#' It saves translation data structure with language key code "key" and
-#' language to translate name "lang" as an example of a translation csv file.
+#' Saves translation data structure to CSV with language key codes "key", "language_code_1" and "language_code_2"
+#' as examples of a translation csv files.
 #'
 #' @param key_expressions vector with key expression to translate
-#' @param output_path character with path to output file (default:
-#' "translate_lang.csv" if NULL)
+#' @param output_path character with path to output directory
+#' @param key_language character specifying the language key code of the key_expressions
+#' @param translated_languages character vector specifying the key codes of the translated languages
+#' @param update logical. If TRUE, the output updates the existing translation file. If FALSE, any existing file of the name is overwritten.
 #' @import utils
+#' @import data.table
 #' @keywords internal
-save_to_csv <- function(key_expressions, output_path = NULL) {
-  df_to_save <- data.frame(
-    list(key = key_expressions, lang = rep("", length(key_expressions)))
-  )
-  if (is.null(output_path)) output_path <- "translate_lang.csv"
-  write.csv(df_to_save, output_path, row.names = FALSE)
+save_to_csv <- function(key_expressions,
+                         output_path = NULL,
+                         key_language = "key",
+                         translated_languages = c("language_code_1", "language_code_2"),
+                         update = TRUE) {
+  ..write_columns <- NULL # avoid NOTE "no visible binding for global variable"
+  if (is.null(output_path)) {output_path <- "."}
+  extracted_translation_table <- prepare_translation_table(key_expressions,
+                                                           output_path,
+                                                           type = "csv",
+                                                           key_language,
+                                                           translated_languages,
+                                                           update)
+
+  for(translated_language in translated_languages){
+    target_csv_file <- paste0("translation_", translated_language, ".csv")
+    write_columns <- c(key_language, translated_language)
+    fwrite(extracted_translation_table[, ..write_columns], file = file.path(output_path, target_csv_file), row.names = FALSE)
+  }
 }
 
 #' Create translation file
@@ -66,23 +172,27 @@ save_to_csv <- function(key_expressions, output_path = NULL) {
 #' Auxiliary shiny.i18n function that searches for all key expressions (e.g.
 #' surrounded by \code{i18n$t()} tag in the script).
 #'
-#' @param path character with path of the file that needs to be inspected for
+#' @param path character vector of one or more paths of the file(s) that needs to be inspected for
 #' key translations
 #' @param type type of the example output file with translations, either "json"
 #' or "csv"
 #' @param handle name of \code{Translator} object within script from \code{path}
-#' @param output if NULL (default) the output will be saved with a default file
-#' name ("translation.json" for JSON and "translate_lang.csv" for CSV)
+#' @param output if NULL (default) and type = "json" the output will be saved with a default file
+#' name ("translation.json"), otherwise a valid path to a *.json file is expected.
+#' For type = "csv" a output path (directory) is expected and files with the pattern "translate_language_code.csv" are saved to disk.
+#' @param key_language character specifying the language key code of the key expressions
+#' @param translated_languages character vector specifying the key codes of the translated languages
+#' @param update logical. If TRUE, the output updates the existing translation file. If FALSE, any existing file of the name is overwritten.
 #'
 #' @export
 create_translation_file <- function(path, type = "json", handle = "i18n",
-                                    output = NULL) {
-  file_source <- readLines(con = file(path))
+                                    output = NULL, key_language = "key", translated_languages = c("language_code_1", "language_code_2"), update = TRUE) {
+  file_source <- unlist(lapply(path, stri_read_lines), use.names = FALSE)
   key_expressions <- extract_key_expressions(file_source, handle)
   switch(type,
-    json = save_to_json(key_expressions, output),
-    csv = save_to_csv(key_expressions, output),
-    stop("'type' of output not recognized, check docs!")
+         json = save_to_json(key_expressions, output, key_language, translated_languages),
+         csv = save_to_csv(key_expressions, output),
+         stop("'type' of output not recognized, check docs!")
   )
 }
 

--- a/R/preproc.R
+++ b/R/preproc.R
@@ -107,6 +107,7 @@ prepare_translation_table <- function(key_expressions,
 #' @param key_expressions vector with key expression to translate
 #' @param output_path character with path to output file (default:
 #' "translation.json" if NULL)
+#' @importFrom jsonlite write_json
 #' @param key_language character specifying the language key code of the key_expressions
 #' @param translated_languages character vector specifying the key codes of the translated languages
 #' @param update logical. If TRUE, the output updates the existing translation file. If FALSE, any existing file of the name is overwritten.

--- a/tests/testthat/test_preproc.R
+++ b/tests/testthat/test_preproc.R
@@ -1,24 +1,21 @@
 context("preproc")
 
+
 test_that("test extract_key_expressions", {
-  txt <- "
-  i18n$t(\"abc\")
-  sadsjdajd
-  i18n$translate(\"xyz zxy\")
-  i18n$translate(\"1 ('abc abc')2\")
-  "
+  txt <- c(
+    'i18n$t(\"abc\")',
+    'sadsjdajd',
+    'i18n$translate(\"xyz zxy\")',
+    'i18n$translate(\"1 (\'abc abc\')2\")'
+  )
   expect_equal(extract_key_expressions(txt), c("abc", "xyz zxy", "1 ('abc abc')2"))
-  txt <- "
-  i18n$t('abc')
-  ajsdjasdadnm
-  i18n$translate('xyz zxy')
-  "
+
+  txt <- c("i18n$t('abc')",
+      "ajsdjasdadnm",
+      "i18n$translate('xyz zxy')")
   expect_equal(extract_key_expressions(txt), c("abc", "xyz zxy"))
-  txt <- "
-  tr$t('abc')
-  ajsdjasdadnm
-  tr$translate('xyz zxy')
-  "
+
+  txt <- c("tr$t('abc')", "ajsdjasdadnm", "tr$translate('xyz zxy')")
   expect_equal(extract_key_expressions(txt, handle = "tr"), c("abc", "xyz zxy"))
 })
 
@@ -30,20 +27,22 @@ test_that("test save_to_json", {
 })
 
 test_that("test save_to_csv", {
-  tmp_file <- "tmp.csv"
-  save_to_csv(c("a", "b"), output_path = tmp_file)
-  expect_true(file.exists(tmp_file))
-  file.remove(tmp_file)
+  languages <- c("language_code_1", "language_code_2")
+  tmp_files <- paste0("translation_", languages, ".csv")
+  save_to_csv(c("a", "b"), output_path = ".", translated_languages = languages)
+  expect_true(all(file.exists(tmp_files)))
+  file.remove(tmp_files)
 })
 
 test_that("test save_to_csv", {
   cat("i18n$t('abc')\nsadsjdajd\ni18n$translate(\"xyz zxy\")\n", file = "tmp.R")
-  tmp_csv <- "tmp.csv"
-  create_translation_file("tmp.R", type = "csv", output = tmp_csv)
-  expect_true(file.exists(tmp_csv))
-  file.remove(tmp_csv)
+  languages <- c("language_code_1", "language_code_2")
+  tmp_files <- paste0("translation_", languages, ".csv")
+  create_translation_file("tmp.R", type = "csv", output = ".")
+  expect_true(all(file.exists(tmp_files)))
+  file.remove(tmp_files)
   tmp_json <- "tmp.json"
-  create_translation_file("tmp.R", type = "json", output = tmp_json)
+  create_translation_file("tmp.R", type = "json", output = tmp_json, translated_languages = c("language_code_1", "language_code_2"))
   expect_true(file.exists(tmp_json))
   file.remove(tmp_json)
   file.remove("tmp.R")


### PR DESCRIPTION
# Refactored preproc functions

- `extract_key_expressions` is now faster by directly utilizing `library(stringi)` instead of `library(stringr)` 
- Added function `prepare_translation_table` (based on {data.table} which is called by `save_to_json` and `save_to_csv`. It allows to read-in previously existing translation files (json or csv) and updates them without overwriting existing translations (implemented to realize create_translation_file's `update` parameter)
- `create_translation_file` is now able to search through multiple R scripts. Furthermore, It gained the parameters `key_language`, `translated_languages` and `update`. The languages are reflected in the resulting translation file with placeholder `""`
- amended tests